### PR TITLE
Fix: Hook to control the visibility of the dropdown once the location changes

### DIFF
--- a/src/components/megamenu/navbar.js
+++ b/src/components/megamenu/navbar.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Link } from 'gatsby';
+import React, { useEffect, useRef, useState } from 'react';
 import CallEmailBtns from './callEmailBtns';
 import ServicesMenu from './servicesMenu';
 
@@ -8,51 +8,50 @@ const NavbarBurger = (props) => (
     onClick={props.toggleMenu}
     className={`navbar-burger burger ${props.active ? 'is-active' : ''}`}
   >
-    <span />
-    <span />
-    <span />
+    <span/>
+    <span/>
+    <span/>
   </div>
 );
 
-export default class Navbar extends React.Component {
-  state = {
-    activeMenu: false,
-  };
-  toggleMenu = () => {
-    this.setState({
-      activeMenu: !this.state.activeMenu,
-    });
+const Navbar = ({ location }) => {
+  const [activeMenu, setActiveMenu] = useState(false);
+  const fakeReference = useRef(null);
+  const toggleMenu = () => {
+    setActiveMenu(!activeMenu);
   };
 
-  render() {
-    return (
-      <nav className='navbar has-background-white-bis has-shadow'>
-        <div className='container'>
-          <div className='navbar-brand'>
-            <NavbarBurger
-              active={this.state.activeMenu}
-              toggleMenu={this.toggleMenu}
-            />
+  return (
+    <nav className='navbar has-background-white-bis has-shadow' ref={fakeReference}>
+      <div className='container'>
+        <div className='navbar-brand'>
+          <NavbarBurger
+            active={activeMenu}
+            toggleMenu={toggleMenu}
+          />
+        </div>
+        <div
+          className={`navbar-menu ${
+            activeMenu ? 'is-active' : ''
+          }`}
+        >
+          <div className='navbar-start'>
+            <Link to={'/'} className='navbar-item' href='/'>
+              Home
+            </Link>
+            <ServicesMenu location={location}/>
           </div>
-          <div
-            className={`navbar-menu ${
-              this.state.activeMenu ? 'is-active' : ''
-            }`}
-          >
-            <div className='navbar-start'>
-              <Link to={'/'} className='navbar-item' href='/'>
-                Home
-              </Link>
-              <ServicesMenu />
-            </div>
-            <div className='navbar-end has-background-white-bis'>
-              <div className='navbar-item'>
-                <CallEmailBtns />
-              </div>
+          <div className='navbar-end has-background-white-bis'>
+            <div className='navbar-item'>
+              <CallEmailBtns/>
             </div>
           </div>
         </div>
-      </nav>
-    );
-  }
-}
+      </div>
+    </nav>
+  );
+
+};
+
+export default Navbar;
+

--- a/src/components/megamenu/servicesMenu.js
+++ b/src/components/megamenu/servicesMenu.js
@@ -1,9 +1,17 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'gatsby';
 import { FaMapMarkerAlt } from 'react-icons/fa';
-const ServicesMenu = () => {
+
+const ServicesMenu = ({location}) => {
+  const [isVisible, setIsVisible]=useState(false)
+
+  useEffect(()=>{
+    setIsVisible(!isVisible)
+    setTimeout(()=>setIsVisible(true),1)
+  },[location])
+
   return (
-    <div className='navbar-item has-dropdown is-hoverable is-mega'>
+    <div className={`navbar-item has-dropdown is-hoverable is-mega`}>
       <div className='navbar-link flex'>
         <FaMapMarkerAlt className='is-size-4 has-text-info' />
         <Link to={'/offices'}> &nbsp;Offices </Link>
@@ -13,8 +21,8 @@ const ServicesMenu = () => {
         className='navbar-dropdown '
         data-style={{ width: '18rem' }}
       >
-        <div className='container is-fluid'>
-          <div className='columns'>
+        <div className={`container is-fluid`}>
+          {isVisible && <div className='columns'>
             <div className='column'>
               <Link to={'/about'}>
                 <h1 className='title is-6 is-mega-menu-title is-hovered'>
@@ -29,7 +37,7 @@ const ServicesMenu = () => {
                 London
               </Link>
             </div>
-          </div>
+          </div>}
         </div>
       </div>
     </div>

--- a/src/components/navbarWrapper.js
+++ b/src/components/navbarWrapper.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 import Navbar from './megamenu/navbar';
 
-const navbarWrapper = ({ children }) => (
+const navbarWrapper = ({ children, location }) => (
   <>
-    <Navbar />
+    <Navbar location={location}/>
     {children}
   </>
 );

--- a/src/html.js
+++ b/src/html.js
@@ -26,16 +26,16 @@ export default function HTML(props) {
           type='text/javascript'
           dangerouslySetInnerHTML={{
             __html: `
-   var adiInit = "76225", adiRVO = true;
-   var adiFunc = null;
-   (function() {
-      var adiSrc = document.createElement("script"); adiSrc.type = "text/javascript";
-      adiSrc.async = true;
-      adiSrc.src = ("https:" == document.location.protocol ? "https://static-ssl" : "http://static-cdn")
-      	+ ".responsetap.com/static/scripts/rTapTrack.min.js";
-      var s = document.getElementsByTagName("script")[0];
-      s.parentNode.insertBefore(adiSrc, s);
-   })();`,
+             var adiInit = "76225", adiRVO = true;
+             var adiFunc = null;
+             (function() {
+                var adiSrc = document.createElement("script"); adiSrc.type = "text/javascript";
+                adiSrc.async = true;
+                adiSrc.src = ("https:" == document.location.protocol ? "https://static-ssl" : "http://static-cdn")
+                  + ".responsetap.com/static/scripts/rTapTrack.min.js";
+                var s = document.getElementsByTagName("script")[0];
+                s.parentNode.insertBefore(adiSrc, s);
+             })();`,
           }}
         />
         {/*RESPONSE TAP tracking code END*/}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,9 +20,9 @@ const IndexPage = () => {
         <div className='section'>
           <div className='container'>
             <Map {...mapOptions}>
-              <Marker position={[53.510302, -2.33581]}></Marker>
-              <Marker position={[53.510302, -1.335001]}></Marker>
-              <Marker position={[53.510302, -3.335001]}></Marker>
+              <Marker position={[53.510302, -2.33581]}/>
+              <Marker position={[53.510302, -1.335001]}/>
+              <Marker position={[53.510302, -3.335001]}/>
             </Map>
           </div>
         </div>


### PR DESCRIPTION
Hi Verner!

I will try to explain a little bit of what I've done.

First of all, having Bulma doesn't help because they add some rigid class names and trying to change them can become very hard.

The main issue was that the old-fashioned function uses the `window` object to operate and in React (also in Gatsby) when dealing with global objects (like `document `or `window`) outside the React ecosystem, they break the rehydration of the components. In this case, I tried to wrap it in an original function of mine but it doesn't behave as expected so I left the `html.js` functionality.

The other issue is that once the location changes, the dropdown holds the state (because it's on `wrapPageElement`, and it's intended to do so) so I've created a custom function that changes the state with a `setTimeout`, making this React's rehydration
force the closing of the dropdown. It is possible that with more time and radical changes you may simplify all this, but given the scenario (Bulma, `wrapPageElement`, and the old function), the way I left it now makes it perfectly functional.

Gif demonstrating the functionality:

![Dropdown closed when navigating](https://user-images.githubusercontent.com/14785182/106306203-fd889780-625d-11eb-9c42-362141460d54.gif)
