### PR TITLE
Fix: open/close behavior in mobile layout

### DIFF
--- a/src/components/megamenu/navbar.js
+++ b/src/components/megamenu/navbar.js
@@ -1,5 +1,6 @@
 import { Link } from 'gatsby';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import useWindowSize from '../../utils/hooks/useWindowSize';
 import CallEmailBtns from './callEmailBtns';
 import ServicesMenu from './servicesMenu';
 
@@ -16,13 +17,22 @@ const NavbarBurger = (props) => (
 
 const Navbar = ({ location }) => {
   const [activeMenu, setActiveMenu] = useState(false);
-  const fakeReference = useRef(null);
-  const toggleMenu = () => {
+  const { width } = useWindowSize();
+  const toggleMenu = () => setActiveMenu(!activeMenu);
+
+  useEffect(() => {
     setActiveMenu(!activeMenu);
-  };
+    if (typeof window !== 'undefined') {
+      if (width >= 1024) setTimeout(() => setActiveMenu(true), 1);
+    }
+  }, [location]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') setActiveMenu(width > 1024);
+  }, [width]);
 
   return (
-    <nav className='navbar has-background-white-bis has-shadow' ref={fakeReference}>
+    <nav className='navbar has-background-white-bis has-shadow'>
       <div className='container'>
         <div className='navbar-brand'>
           <NavbarBurger
@@ -30,23 +40,19 @@ const Navbar = ({ location }) => {
             toggleMenu={toggleMenu}
           />
         </div>
-        <div
-          className={`navbar-menu ${
-            activeMenu ? 'is-active' : ''
-          }`}
-        >
+        {activeMenu && <div className={`navbar-menu ${activeMenu ? 'is-active' : ''}`}>
           <div className='navbar-start'>
             <Link to={'/'} className='navbar-item' href='/'>
               Home
             </Link>
-            <ServicesMenu location={location}/>
+            <ServicesMenu activeMenu={activeMenu}/>
           </div>
           <div className='navbar-end has-background-white-bis'>
             <div className='navbar-item'>
               <CallEmailBtns/>
             </div>
           </div>
-        </div>
+        </div>}
       </div>
     </nav>
   );

--- a/src/components/megamenu/navbar.js
+++ b/src/components/megamenu/navbar.js
@@ -40,7 +40,7 @@ const Navbar = ({ location }) => {
             toggleMenu={toggleMenu}
           />
         </div>
-        {activeMenu && <div className={`navbar-menu ${activeMenu ? 'is-active' : ''}`}>
+        <div className={`navbar-menu ${activeMenu ? 'is-active' : ''}`}>
           <div className='navbar-start'>
             <Link to={'/'} className='navbar-item' href='/'>
               Home
@@ -52,7 +52,7 @@ const Navbar = ({ location }) => {
               <CallEmailBtns/>
             </div>
           </div>
-        </div>}
+        </div>
       </div>
     </nav>
   );

--- a/src/components/megamenu/servicesMenu.js
+++ b/src/components/megamenu/servicesMenu.js
@@ -2,13 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'gatsby';
 import { FaMapMarkerAlt } from 'react-icons/fa';
 
-const ServicesMenu = ({location}) => {
-  const [isVisible, setIsVisible]=useState(false)
+const ServicesMenu = ({activeMenu}) => {
 
-  useEffect(()=>{
-    setIsVisible(!isVisible)
-    setTimeout(()=>setIsVisible(true),1)
-  },[location])
 
   return (
     <div className={`navbar-item has-dropdown is-hoverable is-mega`}>
@@ -22,7 +17,7 @@ const ServicesMenu = ({location}) => {
         data-style={{ width: '18rem' }}
       >
         <div className={`container is-fluid`}>
-          {isVisible && <div className='columns'>
+          {activeMenu && <div className='columns'>
             <div className='column'>
               <Link to={'/about'}>
                 <h1 className='title is-6 is-mega-menu-title is-hovered'>

--- a/src/utils/hooks/useWindowSize.js
+++ b/src/utils/hooks/useWindowSize.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+function useWindowSize () {
+  const [windowSize, setWindowSize] = useState({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    function handleResize () {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+
+    window.addEventListener('resize', handleResize);
+
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
+}
+
+export default useWindowSize;


### PR DESCRIPTION
Hi Verner!

The purpose of this PR is to fix the open/closing menu in the mobile layouts and keeping the desktop behavior. I've added a custom hook to control when the window is being resized and I've refactored a little bit the yesterday's code to remove the unnecessary logic to the buttons component, giving a more flexible structure and reusing some code, passing the only needed data to the component.

As usual, the mandatory `.gif` 😄 :

![Dropdown closed when navigating](https://user-images.githubusercontent.com/14785182/106360096-eb1e6480-6316-11eb-8555-fbe08c12a550.gif)
